### PR TITLE
Serve Linux as a dn2cpp export target

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
@@ -222,13 +222,15 @@ namespace GodotTools.Export
         /// </param>
         public static Dn2CppExporter Create(string godotPlatform, IReadOnlyCollection<string> archs)
         {
-            if (godotPlatform == OS.Platforms.MacOS || godotPlatform == OS.Platforms.Windows)
+            if (godotPlatform == OS.Platforms.MacOS || godotPlatform == OS.Platforms.Windows
+                || godotPlatform == OS.Platforms.LinuxBSD)
             {
-                // The two host-compiled desktop targets. The bundle compiles the
-                // game with the host's own C++ compiler (clang++ on macOS, cl.exe
-                // under the Ninja generator on Windows), so the export machine is
-                // the only machine it can target — neither its operating system nor
-                // its architecture may differ, and the checks are identical.
+                // The host-compiled desktop targets. The bundle compiles the game
+                // with the host's own C++ compiler (clang++ on macOS and Linux,
+                // cl.exe under the Ninja generator on Windows), so the export
+                // machine is the only machine it can target — neither its operating
+                // system nor its architecture may differ, and the checks are
+                // identical.
                 //
                 // The OS is asked FIRST, because the architecture test alone lets a
                 // foreign host straight through: a Linux x86_64 or an Intel macOS
@@ -239,10 +241,16 @@ namespace GodotTools.Export
                 // '<assembly>.dll'" that names no cause. Asking the OS first also
                 // makes the message the right one: a wrong-OS export is not a
                 // cross-architecture refusal.
-                if (godotPlatform == OS.Platforms.Windows ? !OS.IsWindows : !OS.IsMacOS)
-                {
-                    string targetName = godotPlatform == OS.Platforms.Windows ? "Windows" : "macOS";
+                //
+                // One pair per target rather than a ternary: a two-valued "Windows
+                // or else macOS" test silently answers macOS for a third target.
+                (bool hostIsTarget, string targetName) =
+                    godotPlatform == OS.Platforms.Windows ? (OS.IsWindows, "Windows")
+                    : godotPlatform == OS.Platforms.MacOS ? (OS.IsMacOS, "macOS")
+                    : (OS.IsLinuxBSD, "Linux");
 
+                if (!hostIsTarget)
+                {
                     throw new NotSupportedException(
                         "The dn2cpp export backend compiles the game with the host's own C++ compiler, so an " +
                         $"export to {targetName} has to run on {targetName}; this host is not one. Export from a " +
@@ -326,9 +334,9 @@ namespace GodotTools.Export
             else
             {
                 throw new NotSupportedException(
-                    $"The dn2cpp export backend supports Windows, macOS, iOS, Android and Web only for now, not " +
-                    $"'{godotPlatform}'. Switch 'dotnet/export_backend' to 'Host Runtime' or 'NativeAOT' for this " +
-                    "preset.");
+                    $"The dn2cpp export backend supports Windows, macOS, Linux, iOS, Android and Web only for now, " +
+                    $"not '{godotPlatform}'. Switch 'dotnet/export_backend' to 'Host Runtime' or 'NativeAOT' for " +
+                    "this preset.");
             }
 
             // Ahead of the tool search below, which asks the bundle for a cmake and
@@ -563,6 +571,10 @@ namespace GodotTools.Export
             // which is Windows's own: a SHARED target is <name>.dll with NO 'lib'
             // prefix, and the engine opens exactly <assembly>.dll.
             bool targetsWindows = _godotPlatform == OS.Platforms.Windows;
+            // Linux is named for the same reason: host-compiled like the other two
+            // desktops, but its SHARED target is lib<name>.so while the engine
+            // opens <assembly>.so.
+            bool targetsLinux = _godotPlatform == OS.Platforms.LinuxBSD;
             if (targetsWeb)
             {
                 if (arch != WebArch)
@@ -719,7 +731,7 @@ namespace GodotTools.Export
             RunTool(_cmakeExe, new List<string> { "--build", buildDir }, "compiling the drop-in library");
 
             return StageBuiltLibrary(buildDir, stageDir, targetName, assemblyName,
-                targetsWindows, targetsAndroid, targetsWeb);
+                targetsWindows, targetsLinux, targetsAndroid, targetsWeb);
         }
 
         /// <summary>
@@ -828,15 +840,17 @@ namespace GodotTools.Export
         /// its own, under the name the engine opens, and returns that directory.
         /// </summary>
         private string StageBuiltLibrary(string buildDir, string stageDir, string targetName,
-            string assemblyName, bool targetsWindows, bool targetsAndroid, bool targetsWeb)
+            string assemblyName, bool targetsWindows, bool targetsLinux, bool targetsAndroid,
+            bool targetsWeb)
         {
             // What CMake names a SHARED target's output is the platform's rule, not
-            // one convention, and the three Unix-family targets already needed three
-            // different answers. On Apple the linker writes lib<name>.dylib and the
-            // engine opens <name>.dylib — the name a NativeAOT publish produces — so
-            // the lib prefix is dropped when staging. On Android it opens the bare
-            // soname lib<name>.so and lets the linker find it in the APK's lib/<abi>/,
-            // so there the prefix is the whole point: keep it.
+            // one convention, and the Unix-family targets needed a different answer
+            // each. On Apple the linker writes lib<name>.dylib and the engine opens
+            // <name>.dylib — the name a NativeAOT publish produces — so the lib
+            // prefix is dropped when staging. Desktop Linux is that same rule with
+            // .so for the extension. On Android it opens the bare soname
+            // lib<name>.so and lets the linker find it in the APK's lib/<abi>/, so
+            // there the prefix is the whole point: keep it.
             //
             // On the Web the prefix goes, for a third reason. Emscripten names the
             // side module lib<name>.so like any other SHARED target, but the engine
@@ -847,7 +861,8 @@ namespace GodotTools.Export
             // of libraries it preloaded before main(), keyed on the file name the Web
             // exporter copied next to index.html. That is the staged file's name. So
             // the staged file must be exactly <assembly>.so: on this platform the
-            // name is not a convention, it is the entire lookup.
+            // name is not a convention, it is the entire lookup. Desktop Linux lands
+            // on the same staged name by taking that UNIX_ENABLED branch for real.
             //
             // Windows is the fourth, and the only one whose BUILT name is not decided
             // by the platform alone: the no-'lib'-prefix rule is the MSVC ABI's, not
@@ -875,7 +890,7 @@ namespace GodotTools.Export
             else
             {
                 builtLibrary = Path.Combine(buildDir,
-                    $"lib{targetName}.{(targetsAndroid || targetsWeb ? "so" : "dylib")}");
+                    $"lib{targetName}.{(targetsLinux || targetsAndroid || targetsWeb ? "so" : "dylib")}");
                 if (!File.Exists(builtLibrary))
                 {
                     throw new InvalidOperationException(
@@ -886,7 +901,7 @@ namespace GodotTools.Export
             RecreateDirectory(stageDir);
             string stagedName = targetsWindows ? $"{assemblyName}.dll"
                 : targetsAndroid ? $"lib{assemblyName}.so"
-                : targetsWeb ? $"{assemblyName}.so"
+                : targetsWeb || targetsLinux ? $"{assemblyName}.so"
                 : $"{assemblyName}.dylib";
             string stagedLibrary = Path.Combine(stageDir, stagedName);
             File.Copy(builtLibrary, stagedLibrary, overwrite: true);


### PR DESCRIPTION
The export backend already treated Linux as a **host** — `HostCxxCompiler` resolves `clang++`/`g++` and the missing-compiler remedy names a distribution's package manager — but `Dn2CppExporter.Create()` admitted only macOS and Windows, so a `LinuxBSD` preset fell through to the unsupported-platform throw. A Linux desktop export was the one desktop target the backend could build for and refused to.

## What is wrong

**The host test could not simply gain a third case.** It read:

```csharp
if (godotPlatform == OS.Platforms.Windows ? !OS.IsWindows : !OS.IsMacOS)
```

Two-valued: everything that is not Windows is assumed to be macOS. Adding Linux to the admission above it would have left this line answering *macOS* for a Linux target — a cross-compile refusal naming the wrong OS, or none at all. It is now one `(hostPredicate, targetName)` pair per target, so a fourth target cannot inherit a third target's answer by falling off the end.

**Staging is the Web's rule reached for a different reason.** cmake writes `lib<name>.so`; the engine opens `<assembly>.so` with no `lib` prefix. Linux and the Web agree on that name, but not by coincidence and not for the same reason as Android, which keeps the prefix: desktop Linux is the `UNIX_ENABLED` branch of `try_load_native_aot_library` that the Web only borrows. Android is a separate branch and a separate name. The three are now spelled out separately rather than sharing a ternary that happens to agree today.

## Effect on the engine hash

None. `FORK_OWNED` excludes `modules/mono/editor/GodotTools`, so this change lands in `TOOLS_OWNED`: it triggers a `build_assemblies.py` rerun and neither a scons rebuild nor movement in the interop-ABI fingerprint.

## Verification

Driven from the dn2cpp side, where the oracle lives. `gates/build-and-run-godot-editor-export.sh` is green on a Linux x86_64 host against a scons-built fork editor and `template_release`: all thirteen sections ran, with sections 9 and 12 the only expected partials — the two whose state exists on a Windows host alone.

What that actually exercised here, rather than merely compiled:

- The export produced `libEditorExportSample.so` and staged it as `EditorExportSample.so` under `data_EditorExportSample_linuxbsd_x86_64/`, and the exported game ran in a real engine emitting all five of its markers.
- The three refusal strings `export to macOS has to run on macOS`, `apt install clang` and `cannot cross-compile` all appear in the export logs, so the three-valued host test and the Linux remedy arm fired for real rather than being asserted by inspection.

**Not verified here: the macOS and Windows regressions.** Section 10 (foreign-preset refusal) is the oracle for the host test on those platforms and it can only run on each of them. This branch changes the shape of that test for every target, so it wants a run of that gate on a macOS host and on a Windows host before it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A2sXbBEgqHVNHsSDAbJtK
