### PR TITLE
Verify the Web drop-in's wasm import closure

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
@@ -152,6 +152,13 @@ namespace GodotTools.Export
         private readonly HashSet<string> _transpiled = new HashSet<string>();
 
         /// <summary>
+        /// File names of the wasm side modules this export staged — the drop-in and
+        /// every extra shared object. Recorded for <c>_ExportEnd</c>'s import-closure
+        /// check, which runs after the platform exporter has written the page.
+        /// </summary>
+        private readonly List<string> _stagedWebModules = new List<string>();
+
+        /// <summary>
         /// The slot layout of <c>.godot/mono/dn2cpp</c>, recorded in the work dir as
         /// <c>layout.txt</c>. Bump it whenever a slot's NAME changes: 2 is GE-6's
         /// per-config <c>il/</c> and <c>gen/</c>, 1 the per-RID ones before it (and
@@ -905,6 +912,8 @@ namespace GodotTools.Export
                 : $"{assemblyName}.dylib";
             string stagedLibrary = Path.Combine(stageDir, stagedName);
             File.Copy(builtLibrary, stagedLibrary, overwrite: true);
+            if (targetsWeb)
+                _stagedWebModules.Add(stagedName);
 
             // Nothing copies it into the publish directory as well. The iOS
             // packaging tail lipos one {assembly}.dylib per entry of the export's
@@ -934,6 +943,8 @@ namespace GodotTools.Export
 
                 string stagedSharedObject = Path.Combine(stageDir, Path.GetFileName(sharedObject));
                 File.Copy(sharedObject, stagedSharedObject, overwrite: true);
+                if (targetsWeb)
+                    _stagedWebModules.Add(Path.GetFileName(sharedObject));
                 LogLine($"staged {stagedSharedObject}");
                 GD.Print($"dn2cpp: staged extra shared object {stagedSharedObject}");
             }
@@ -2099,6 +2110,171 @@ namespace GodotTools.Export
 
             return string.Equals(Normalize(a), Normalize(b),
                 OS.IsWindows ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// What <c>_ExportEnd</c>'s Web import-closure check needs, captured before
+        /// this exporter is disposed; null when this export staged no wasm side
+        /// module (every non-Web target).
+        /// </summary>
+        public WebImportCheck? GetWebImportCheck() =>
+            _stagedWebModules.Count > 0
+                ? new WebImportCheck(_toolchain.Dn2CppExe, _stagedWebModules.ToArray())
+                : null;
+
+        /// <summary>
+        /// Verifies each staged side module's imports against the exported page's
+        /// main module and JS glue, via <c>dn2cpp --check-wasm-imports</c>. Runs from
+        /// <c>_ExportEnd</c> — the only plugin hook after the platform exporter has
+        /// written those files — because Emscripten's dlopen does not fail on an
+        /// unresolved symbol: the game ships, loads, and dies in the player's browser
+        /// with 'TypeError: resolved is not a function' naming a wasm function index
+        /// and nothing else. So the import set is asserted statically, here.
+        /// </summary>
+        internal sealed class WebImportCheck
+        {
+            private const string MessageCategory = "Export .NET Project";
+
+            private readonly string _dn2cppExe;
+            private readonly string[] _sideModules;
+
+            internal WebImportCheck(string dn2cppExe, string[] sideModules)
+            {
+                _dn2cppExe = dn2cppExe;
+                _sideModules = sideModules;
+            }
+
+            /// <summary>
+            /// An unsatisfied import is an Error — the export dialog reports the
+            /// export as failed. A check that could not run is a Warning: never
+            /// reported as a broken game, never allowed to pass silently.
+            /// </summary>
+            public void Verify(string exportPath, EditorExportPlatform platform)
+            {
+                // "Export PCK/ZIP" fires the begin/end hooks too, with a .pck/.zip
+                // path — no platform exporter runs and no wasm is written. The Web's
+                // real export target is always .html.
+                if (!exportPath.EndsWith(".html", StringComparison.OrdinalIgnoreCase))
+                    return;
+
+                string baseDir = Path.GetDirectoryName(Path.GetFullPath(exportPath))!;
+                string basename = Path.GetFileNameWithoutExtension(exportPath);
+                string mainWasm = Path.Combine(baseDir, basename + ".wasm");
+                string mainJs = Path.Combine(baseDir, basename + ".js");
+
+                // The main module appears at template extraction, after every step
+                // that can fail the export — an export that died earlier has its own
+                // error in the dialog and nothing here to check against.
+                if (!File.Exists(mainWasm))
+                    return;
+
+                if (!File.Exists(mainJs))
+                {
+                    CouldNotRun(platform, string.Join(", ", _sideModules),
+                        $"the main module's JS glue '{mainJs}' is not in the exported page");
+                    return;
+                }
+
+                foreach (string sideModule in _sideModules)
+                {
+                    string sidePath = Path.Combine(baseDir, sideModule);
+                    if (!File.Exists(sidePath))
+                    {
+                        CouldNotRun(platform, sideModule, $"'{sidePath}' is not in the exported page");
+                        continue;
+                    }
+
+                    int exitCode;
+                    List<string> stdout, stderr;
+                    try
+                    {
+                        (exitCode, stdout, stderr) = RunChecker(sidePath, mainWasm, mainJs);
+                    }
+                    catch (Exception e) when (e is System.ComponentModel.Win32Exception
+                                                  or InvalidOperationException or IOException)
+                    {
+                        CouldNotRun(platform, sideModule, $"'{_dn2cppExe}' could not be run: {e.Message}");
+                        continue;
+                    }
+
+                    if (exitCode == 0)
+                    {
+                        GD.Print($"dn2cpp: wasm import closure verified: {sideModule}");
+                        continue;
+                    }
+
+                    if (exitCode == 3 && stdout.Count > 0)
+                    {
+                        platform.AddMessage(EditorExportPlatform.ExportMessageType.Error, MessageCategory,
+                            $"'{sideModule}' imports symbols nothing in the exported page defines. Emscripten's " +
+                            "dlopen does not fail on an unresolved symbol, so the game would ship and die in the " +
+                            "player's browser at the first call, as 'TypeError: resolved is not a function' naming " +
+                            "a wasm function index and nothing else. Unsatisfied:\n  " +
+                            string.Join("\n  ", stdout) + "\n" +
+                            "A SystemNative_* name is a .NET PAL symbol the wasm build does not define — dn2cpp's " +
+                            "runtime/core/platform/wasm/ carries only the sliver this target needs, and the symbol " +
+                            "is added there. A symbol of a library staged through " +
+                            $"'{ExtraSharedObjectsSetting}' must be exported by the page's main module or by " +
+                            "another staged module.");
+                        continue;
+                    }
+
+                    // Exit 2 (unreadable input, or a dn2cpp predating the
+                    // subcommand) or any other surprise: the checker refused to
+                    // answer, which is not an answer.
+                    CouldNotRun(platform, sideModule,
+                        $"'{_dn2cppExe} --check-wasm-imports' exited {exitCode}: " +
+                        (stderr.FirstOrDefault() ?? stdout.FirstOrDefault() ?? "no output"));
+                }
+            }
+
+            private static void CouldNotRun(EditorExportPlatform platform, string what, string reason)
+            {
+                platform.AddMessage(EditorExportPlatform.ExportMessageType.Warning, MessageCategory,
+                    $"The wasm import-closure check did not run over '{what}': {reason}. That is a failure of " +
+                    "the check, not proof the game is broken — but its imports ship unverified, and an " +
+                    "unresolved symbol only surfaces in the player's browser.");
+            }
+
+            private (int ExitCode, List<string> Stdout, List<string> Stderr) RunChecker(
+                string sidePath, string mainWasm, string mainJs)
+            {
+                using var process = new Process
+                {
+                    StartInfo = new ProcessStartInfo(_dn2cppExe)
+                    {
+                        UseShellExecute = false,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        CreateNoWindow = true,
+                    },
+                };
+
+                foreach (string arg in new[] { "--check-wasm-imports", sidePath, mainWasm, mainJs })
+                    process.StartInfo.ArgumentList.Add(arg);
+
+                var stdout = new List<string>();
+                var stderr = new List<string>();
+                process.OutputDataReceived += (_, e) =>
+                {
+                    if (e.Data is not null)
+                        stdout.Add(e.Data);
+                };
+                process.ErrorDataReceived += (_, e) =>
+                {
+                    if (e.Data is not null)
+                        stderr.Add(e.Data);
+                };
+
+                process.Start();
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+                // Drains both asynchronous readers before returning, so the lists
+                // are complete and no longer written to.
+                process.WaitForExit();
+
+                return (process.ExitCode, stdout, stderr);
+            }
         }
 
         public void Dispose()

--- a/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
@@ -2124,7 +2124,8 @@ namespace GodotTools.Export
 
         /// <summary>
         /// Verifies each staged side module's imports against the exported page's
-        /// main module and JS glue, via <c>dn2cpp --check-wasm-imports</c>. Runs from
+        /// main module, JS glue and the other staged modules, via
+        /// <c>dn2cpp --check-wasm-imports</c>. Runs from
         /// <c>_ExportEnd</c> — the only plugin hook after the platform exporter has
         /// written those files — because Emscripten's dlopen does not fail on an
         /// unresolved symbol: the game ships, loads, and dies in the player's browser
@@ -2162,11 +2163,15 @@ namespace GodotTools.Export
                 string mainWasm = Path.Combine(baseDir, basename + ".wasm");
                 string mainJs = Path.Combine(baseDir, basename + ".js");
 
-                // The main module appears at template extraction, after every step
-                // that can fail the export — an export that died earlier has its own
-                // error in the dialog and nothing here to check against.
+                // The main module appears at template extraction, so its absence
+                // means the export died earlier — but that death has its own error
+                // and this check still did not run, which must be said.
                 if (!File.Exists(mainWasm))
+                {
+                    CouldNotRun(platform, string.Join(", ", _sideModules),
+                        $"the main module '{mainWasm}' is not in the exported page");
                     return;
+                }
 
                 if (!File.Exists(mainJs))
                 {
@@ -2174,6 +2179,11 @@ namespace GodotTools.Export
                         $"the main module's JS glue '{mainJs}' is not in the exported page");
                     return;
                 }
+
+                string[] stagedPaths = _sideModules
+                    .Select(m => Path.Combine(baseDir, m))
+                    .Where(File.Exists)
+                    .ToArray();
 
                 foreach (string sideModule in _sideModules)
                 {
@@ -2184,11 +2194,16 @@ namespace GodotTools.Export
                         continue;
                     }
 
+                    // Emscripten merges every loaded module's exports into one
+                    // symbol pool, so a staged sibling legitimately satisfies this
+                    // module's imports — its exports join the check as peers.
+                    string[] peers = stagedPaths.Where(p => p != sidePath).ToArray();
+
                     int exitCode;
                     List<string> stdout, stderr;
                     try
                     {
-                        (exitCode, stdout, stderr) = RunChecker(sidePath, mainWasm, mainJs);
+                        (exitCode, stdout, stderr) = RunChecker(sidePath, mainWasm, mainJs, peers);
                     }
                     catch (Exception e) when (e is System.ComponentModel.Win32Exception
                                                   or InvalidOperationException or IOException)
@@ -2206,22 +2221,24 @@ namespace GodotTools.Export
                     if (exitCode == 3 && stdout.Count > 0)
                     {
                         platform.AddMessage(EditorExportPlatform.ExportMessageType.Error, MessageCategory,
-                            $"'{sideModule}' imports symbols nothing in the exported page defines. Emscripten's " +
-                            "dlopen does not fail on an unresolved symbol, so the game would ship and die in the " +
-                            "player's browser at the first call, as 'TypeError: resolved is not a function' naming " +
-                            "a wasm function index and nothing else. Unsatisfied:\n  " +
+                            $"'{sideModule}' imports symbols nothing in the exported page defines — not the main " +
+                            "module, not its JS glue, not any other staged module. Emscripten's dlopen does not " +
+                            "fail on an unresolved symbol, so the game would ship and die in the player's browser " +
+                            "at the first call, as 'TypeError: resolved is not a function' naming a wasm function " +
+                            "index and nothing else. Unsatisfied:\n  " +
                             string.Join("\n  ", stdout) + "\n" +
                             "A SystemNative_* name is a .NET PAL symbol the wasm build does not define — dn2cpp's " +
                             "runtime/core/platform/wasm/ carries only the sliver this target needs, and the symbol " +
-                            "is added there. A symbol of a library staged through " +
-                            $"'{ExtraSharedObjectsSetting}' must be exported by the page's main module or by " +
-                            "another staged module.");
+                            "is added there. For a symbol of a library staged through " +
+                            $"'{ExtraSharedObjectsSetting}', the library that defines it must be staged too, or " +
+                            "the module that was staged must be rebuilt to export it.");
                         continue;
                     }
 
                     // Exit 2 (unreadable input, or a dn2cpp predating the
-                    // subcommand) or any other surprise: the checker refused to
-                    // answer, which is not an answer.
+                    // subcommand), exit 1 (one predating --peer-module) or any
+                    // other surprise: the checker refused to answer, which is
+                    // not an answer.
                     CouldNotRun(platform, sideModule,
                         $"'{_dn2cppExe} --check-wasm-imports' exited {exitCode}: " +
                         (stderr.FirstOrDefault() ?? stdout.FirstOrDefault() ?? "no output"));
@@ -2237,7 +2254,7 @@ namespace GodotTools.Export
             }
 
             private (int ExitCode, List<string> Stdout, List<string> Stderr) RunChecker(
-                string sidePath, string mainWasm, string mainJs)
+                string sidePath, string mainWasm, string mainJs, string[] peers)
             {
                 using var process = new Process
                 {
@@ -2252,6 +2269,11 @@ namespace GodotTools.Export
 
                 foreach (string arg in new[] { "--check-wasm-imports", sidePath, mainWasm, mainJs })
                     process.StartInfo.ArgumentList.Add(arg);
+                foreach (string peer in peers)
+                {
+                    process.StartInfo.ArgumentList.Add("--peer-module");
+                    process.StartInfo.ArgumentList.Add(peer);
+                }
 
                 var stdout = new List<string>();
                 var stderr = new List<string>();

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -40,6 +40,12 @@ namespace GodotTools.Export
 
         private List<string> _tempFolders = new List<string>();
 
+        // _ExportEnd takes no arguments, so what the Web import-closure check needs
+        // is remembered across the export: the path the export is writing to, and
+        // the check the exporter prepared (null on every non-Web export).
+        private string? _exportPath;
+        private Dn2CppExporter.WebImportCheck? _webImportCheck;
+
         private static bool ProjectContainsDotNet()
         {
             return File.Exists(GodotSharpDirs.ProjectSlnPath);
@@ -190,6 +196,9 @@ namespace GodotTools.Export
         public override void _ExportBegin(string[] features, bool isDebug, string path, uint flags)
         {
             base._ExportBegin(features, isDebug, path, flags);
+
+            _exportPath = path;
+            _webImportCheck = null;
 
             try
             {
@@ -610,6 +619,8 @@ namespace GodotTools.Export
 
                 AddAppleEmbeddedPlatformEmbeddedFramework(xcFrameworkPath);
             }
+
+            _webImportCheck = dn2CppExporter?.GetWebImportCheck();
         }
 
         private static void RecursePublishContents(string path, Func<string, bool> filterDir,
@@ -781,6 +792,30 @@ namespace GodotTools.Export
         public override void _ExportEnd()
         {
             base._ExportEnd();
+
+            // The one hook after the platform exporter has written the page, so it
+            // is where the Web drop-in's import closure can be checked against the
+            // staged main module. Messages added here still reach the export dialog,
+            // and an Error one makes it report failure — _ExportEnd has no return
+            // value to fail the export with.
+            if (_webImportCheck is { } webImportCheck && _exportPath is { } exportPath)
+            {
+                _webImportCheck = null;
+                _exportPath = null;
+                try
+                {
+                    webImportCheck.Verify(exportPath, GetExportPlatform());
+                }
+                catch (Exception e)
+                {
+                    // The check failing to run is not the game being broken, but it
+                    // must not pass silently either.
+                    GetExportPlatform().AddMessage(EditorExportPlatform.ExportMessageType.Warning,
+                        "Export .NET Project",
+                        $"The wasm import-closure check itself failed: {e.Message}. The exported game's imports " +
+                        "ship unverified.");
+                }
+            }
 
             string aotTempDir = Path.Combine(Path.GetTempPath(), $"godot-aot-{System.Environment.ProcessId}");
 


### PR DESCRIPTION
The engine half of the Web import-closure check. Pairs with
takuma-komatsu/dn2cpp#36, which adds the checker itself; neither is
useful alone — this commit calls a subcommand that only exists there,
and that subcommand has no caller without this.

## Why

A C# game exported to the Web can reach a PAL symbol the wasm build does
not define. Emscripten's `dlopen` does not fail on an unresolved symbol:
the game ships, loads, and dies in the player's browser with
`TypeError: resolved is not a function` naming a wasm function index and
nothing else, with nothing in the export log. So the import set is
asserted statically, at export time.

## Where the hook goes, and why there

`_export_end` is the only plugin hook that runs after the platform
exporter has written the page — the drop-in is staged during
`_export_begin`, but `index.wasm` / `index.js` only appear at
`_extract_template`, well after. It takes no arguments, so the export
path is remembered during `_ExportBegin`.

At that point the drop-in `<Assembly>.so`, each `extra_shared_objects`
library, the main module and its glue are all plain readable files in one
directory, and `dn2cpp --check-wasm-imports` is run over each side
module.

## How it surfaces

- unsatisfied imports (exit 3) → `AddMessage(Error, …)` listing every
  symbol, with the browser failure it prevents and where a missing
  `SystemNative_*` is added. `fill_log_messages` reads
  `get_worst_message_type()`, so an Error raised from `_export_end` still
  makes the dialog report the export as failed.
- the check could not run (exit 2, no CLI, a missing file) →
  `AddMessage(Warning, …)`. Never reported as a broken game, never
  allowed to pass silently.

Skipped without a message where there is nothing to check: any non-Web
target, the Export PCK/ZIP path (which fires both hooks with a
`.pck`/`.zip` path and runs no platform exporter), and an export that
died before the template was extracted — that failure is already in the
dialog.

## Verification

GodotTools builds (`modules/mono/build_scripts/build_assemblies.py`).
The CLI's exit-code contract was measured directly, in the same
invocation shape this code uses, against a real exported page left by a
gate run: exit 0 on the actual drop-in, exit 3 with the symbol list, exit
2 for a missing file and for a glue with no `wasmImports`.

Not verified: a real export through a rebuilt fork editor, which needs a
full engine rebuild and repackage. The success path is covered
independently by `gates/build-and-run-godot-editor-export-web.sh`, which
asserts the same closure from the node oracle; the Error and Warning
paths are not exercised by any gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195ZAs6bCodvke92pzhhmi9