### PR TITLE
Fail a headless export on an export-plugin error

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1405,6 +1405,10 @@ void EditorNode::_fs_changed() {
 						err = platform->export_project(export_preset, export_defer.debug, export_path);
 					}
 				}
+				// An error-class message is a failed export, mirroring fill_log_messages()' verdict in the GUI.
+				if (err == OK && platform->get_worst_message_type() >= EditorExportPlatform::EXPORT_MESSAGE_ERROR) {
+					err = FAILED;
+				}
 				if (err != OK) {
 					export_error = vformat("Project export for preset \"%s\" failed.", preset_name);
 				} else if (platform->get_worst_message_type() >= EditorExportPlatform::EXPORT_MESSAGE_WARNING) {

--- a/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
@@ -2146,8 +2146,9 @@ namespace GodotTools.Export
             }
 
             /// <summary>
-            /// An unsatisfied import is an Error — the export dialog reports the
-            /// export as failed. A check that could not run is a Warning: never
+            /// An unsatisfied import, or a staged module absent from the page, is
+            /// an Error — the export is reported as failed, and a headless export
+            /// exits non-zero. A check that could not run is a Warning: never
             /// reported as a broken game, never allowed to pass silently.
             /// </summary>
             public void Verify(string exportPath, EditorExportPlatform platform)
@@ -2188,9 +2189,14 @@ namespace GodotTools.Export
                 foreach (string sideModule in _sideModules)
                 {
                     string sidePath = Path.Combine(baseDir, sideModule);
+                    // This module was staged, so its absence from the page is not a
+                    // check that could not run: the game has no code to load.
                     if (!File.Exists(sidePath))
                     {
-                        CouldNotRun(platform, sideModule, $"'{sidePath}' is not in the exported page");
+                        platform.AddMessage(EditorExportPlatform.ExportMessageType.Error, MessageCategory,
+                            $"The compiled game module '{sideModule}' was staged for this export but '{sidePath}' " +
+                            "is not in the exported page. The exported game has nothing to load its C# code from " +
+                            "and cannot run.");
                         continue;
                     }
 

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -795,9 +795,9 @@ namespace GodotTools.Export
 
             // The one hook after the platform exporter has written the page, so it
             // is where the Web drop-in's import closure can be checked against the
-            // staged main module. Messages added here still reach the export dialog,
-            // and an Error one makes it report failure — _ExportEnd has no return
-            // value to fail the export with.
+            // staged main module. _ExportEnd has no return value, so an Error message
+            // is the only channel that fails the export: the dialog reports failure
+            // and a headless export exits non-zero.
             if (_webImportCheck is { } webImportCheck && _exportPath is { } exportPath)
             {
                 _webImportCheck = null;


### PR DESCRIPTION
## Summary

- `--headless --export-release` exited 0 when an export plugin reported an `EXPORT_MESSAGE_ERROR` — `EditorNode::_fs_changed` only failed on `err != OK` and downgraded an error-class message to "completed with warnings". A failed dn2cpp transpile therefore produced a plausible-looking Web bundle with no `<Assembly>.so`, exit 0. Now an error-class message is a failed export (`Project export for preset "…" failed.`, `EXIT_FAILURE`), mirroring `fill_log_messages()`' verdict in the GUI. Warnings keep the current behaviour.
- The Web import-closure check reports a staged side module absent from the exported page as an Error (was a Warning), so the "no `.so`" footprint of a failed transpile is caught a second time.
- `_ExportEnd` comment corrected: an Error message is the only channel that fails the export.

Fixes takuma-komatsu/dn2cpp#37.

## Verification

- Manual: sample Web project with `dotnet/dn2cpp/extra_transpile_args=PackedStringArray("--not-a-real-flag")` → exit code 1, `ERROR: Export .NET Project: dn2cpp export failed while transpiling the game assembly (exit code 1).`, `ERROR: Project export for preset "dn2cpp-web" failed.`, no `.so` in the output. Before this change the same run exited 0 with "completed with warnings".
- dn2cpp side (companion PR in takuma-komatsu/dn2cpp): the editor-export gates now assert the exit code and a new negative section proves the transpile-failure path; Release/Debug suites 127/127 under `REQUIRE_ALL` with this editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8YWxpuXqGQ7XMWWy97RK8