### PR TITLE
Pass stripping controls during dn2cpp export

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
@@ -788,6 +788,14 @@ namespace GodotTools.Export
             transpileArgs.Add("-r");
             transpileArgs.Add(_toolchain.RuntimeShim);
             transpileArgs.Add("--auto-ref");
+            // link.xml belongs to the source project, not the transient publish output.
+            transpileArgs.Add("--project-root");
+            transpileArgs.Add(Path.GetDirectoryName(GodotSharpDirs.ProjectCsProjPath)!);
+            if (_godotPlatform == OS.Platforms.Windows)
+            {
+                transpileArgs.Add("--link-feature");
+                transpileArgs.Add("com");
+            }
             // Web only, and not an optimization: without it the game does not load at all.
             // The Web target links the generated C++ as an Emscripten wasm SIDE MODULE, and
             // a side module's __wasm_apply_data_relocs — one i32.store per pointer that lives


### PR DESCRIPTION
## Summary

- pass the C# project directory as the dn2cpp project root during export
- enable the com link feature for Windows exports only
- leave sre and remoting disabled by default

Depends on https://github.com/takuma-komatsu/dn2cpp/pull/47.

## Verification

- GodotTools solution build: 0 warnings, 0 errors
- fork pin and interop ABI checks passed against this worktree
- dn2cpp self-hosted toolchain packaging and editor-bundle staging completed

The full desktop editor-export gate was stopped during the expensive whole-bundle content verification before export; the dn2cpp pre-merge gate remains a manual handoff.