### PR TITLE
🤖 Fix NativeAOT DLL dependency lookup

### DIFF
--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -504,7 +504,13 @@ godot_plugins_initialize_fn try_load_native_aot_library(void *&r_aot_dll_handle)
 #error "Platform not supported (yet?)"
 #endif
 
+#if defined(WINDOWS_ENABLED)
+	OS::GDExtensionData library_data;
+	library_data.also_set_library_path = true;
+	Error err = OS::get_singleton()->open_dynamic_library(native_aot_so_path, r_aot_dll_handle, &library_data);
+#else
 	Error err = OS::get_singleton()->open_dynamic_library(native_aot_so_path, r_aot_dll_handle);
+#endif
 
 	if (err != OK) {
 		return nullptr;


### PR DESCRIPTION
> [!INFO]
> *AI disclosure*: This contribution was authored by an autonomous AI agent, on behalf of a user to fix Windows NativeAOT dependency lookup for the dn2cpp Godot fork.

## Summary

- Include the NativeAOT drop-in directory in Windows DLL dependency lookup.
- Scope the search-path request to `try_load_native_aot_library`.
- Leave every other dynamic-library open and non-Windows target unchanged.

## Validation

- Rebuilt the fork editor and Windows release template with `gates/setup-godot-fork.sh` from the companion dn2cpp change.
- Passed the Windows editor-export gate with a PE dependency present only beside the NativeAOT drop-in.
- Exported Thrive and reached `Thrive Startup Succeeded` with `--skip-cpu-check`.