### PR TITLE
Support Web diagnostic symbols

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
@@ -550,7 +550,7 @@ namespace GodotTools.Export
         /// alongside would route the exported game straight back to the .NET host.
         /// </remarks>
         public string BuildDropIn(string publishOutputDir, string assemblyName, string buildConfig,
-            string runtimeIdentifier, string arch, string? macOSDeploymentTarget, bool keepWebSymbols)
+            string runtimeIdentifier, string arch, string? macOSDeploymentTarget, bool keepSymbols)
         {
             // Create refuses any target set the backend cannot build, but it sees
             // one publish config and the caller loops over every architecture of
@@ -723,17 +723,19 @@ namespace GodotTools.Export
             // never resets a cached variable, so an emptied setting must
             // overwrite the cache rather than leave the previous export's flags
             // armed.
-            string[] projectLinkFlags = GetPathListSetting(ExtraLinkFlagsSetting);
-            var appLinkFlags = new List<string>(projectLinkFlags);
-            if (targetsWeb && keepWebSymbols)
+            string projectLinkFlags = string.Join(' ', GetPathListSetting(ExtraLinkFlagsSetting));
+            string extraLinkFlags = projectLinkFlags;
+            if (targetsWeb && keepSymbols)
             {
-                appLinkFlags.Add("-g2");
-                GD.Print("dn2cpp: keeping Web function names (-g2)");
+                if (extraLinkFlags.Length > 0)
+                    extraLinkFlags += " ";
+                extraLinkFlags += "-g2";
             }
-            string extraLinkFlags = string.Join(' ', appLinkFlags);
             string extraLinkLibs = string.Join(' ', GetPathListSetting(ExtraLinkLibsSetting));
             if (projectLinkFlags.Length > 0)
-                GD.Print($"dn2cpp: extra link flags (project setting): {string.Join(' ', projectLinkFlags)}");
+                GD.Print($"dn2cpp: extra link flags (project setting): {projectLinkFlags}");
+            if (targetsWeb && keepSymbols)
+                GD.Print("dn2cpp: keeping Web symbols (-g2)");
             if (extraLinkLibs.Length > 0)
                 GD.Print($"dn2cpp: extra link libs (project setting): {extraLinkLibs}");
             configureArgs.Add($"-DDN2CPP_APP_LINK_FLAGS={extraLinkFlags}");

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -36,6 +36,8 @@ namespace GodotTools.Export
             Dn2Cpp = 2,
         }
 
+        private const string KeepSymbolsSetting = "dotnet/dn2cpp/keep_symbols";
+
         public override string _GetName() => "C#";
 
         private List<string> _tempFolders = new List<string>();
@@ -90,7 +92,7 @@ namespace GodotTools.Export
                         {
                             "option", new Godot.Collections.Dictionary()
                             {
-                                { "name", "dotnet/dn2cpp/keep_symbols" },
+                                { "name", KeepSymbolsSetting },
                                 { "type", (int)Variant.Type.Bool }
                             }
                         },
@@ -251,8 +253,6 @@ namespace GodotTools.Export
             }
 
             var exportBackend = (ExportBackend)(int)GetOption("dotnet/export_backend");
-            bool keepWebSymbols = platform == OS.Platforms.Web
-                && (bool)GetOption("dotnet/dn2cpp/keep_symbols");
 
             // Read before anything is published: every way the Web can fail is a
             // preset checkbox, and finding that out after a transpile and a native
@@ -261,6 +261,8 @@ namespace GodotTools.Export
             {
                 VerifyWebPreset(exportBackend, features);
             }
+
+            bool keepSymbols = platform == OS.Platforms.Web && (bool)GetOption(KeepSymbolsSetting);
 
             bool useAndroidLinuxBionic = (bool)GetOption("dotnet/android_use_linux_bionic");
             PublishConfig publishConfig = new()
@@ -482,7 +484,7 @@ namespace GodotTools.Export
                         : null;
                     string? dn2CppContentsDir = dn2CppExporter?.BuildDropIn(publishOutputDir,
                         GodotSharpDirs.ProjectAssemblyName, buildConfig, runtimeIdentifier, arch,
-                        macOSDeploymentTarget, keepWebSymbols);
+                        macOSDeploymentTarget, keepSymbols);
 
                     // Where THIS slot's library landed, for the iOS tail below: it
                     // reads one {Assembly}.dylib per entry, so an entry has to be a


### PR DESCRIPTION
## Summary

- Add the Web-only `dotnet/dn2cpp/keep_symbols` export option.
- Append `-g2` after project link flags when enabled.
- Reapply the complete effective flag string on every persistent CMake configure.

## Root cause

The dn2cpp Web gate started exercising `keep_symbols` before the forked GodotTools exporter implemented the corresponding option. The pre-merge cache was current for the unchanged fork sources, so it correctly reused an editor that could not satisfy the new gate contract.

## Validation

- `DN2CPP_GATE_CACHE=0 ./gates/build-and-run-godot-editor-export-web.sh`
- Web export passed the `false -> true -> false` persistent-CMake check, wasm name-section assertions, browser run, failure export, and non-dlink refusal.
- GodotTools managed assemblies rebuilt successfully.

This is a normal, non-amended commit.