### PR TITLE
Normalize POSIX spelling

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
@@ -512,7 +512,7 @@ namespace GodotTools.Export
                 VerifyEmscriptenNode(emscripten);
             }
 
-            // A cross-target export off a Windows host transpiles the POSIX-flavour
+            // A cross-target export off a Windows host transpiles the POSIX flavor
             // framework, not the bundle's host one (Dn2CppToolchain.NeedsCrossCoreLib
             // says why). Checked here rather than at the -r, because the alternative
             // is not a missing file: the transpile SUCCEEDS against the Windows


### PR DESCRIPTION
## Summary

- Normalize the remaining `POSIX-flavour` spelling in the Web export comments.

## Validation

- Branch is based directly on `origin/dn2cpp/main`.
- This PR contains exactly one commit and one line change.
- `git diff --check` passes.

The Web diagnostic-symbol implementation is already present on the base branch; this PR only fixes the spelling that caused the prior status-check failure.