### PR TITLE
Expose dn2cpp incremental GC export setting

### DIFF
--- a/editor/inspector/editor_property_name_processor.cpp
+++ b/editor/inspector/editor_property_name_processor.cpp
@@ -177,6 +177,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["db"] = "dB";
 	capitalize_string_remaps["dof"] = "DoF";
 	capitalize_string_remaps["dpi"] = "DPI";
+	capitalize_string_remaps["dn2cpp"] = "dn2cpp";
 	capitalize_string_remaps["dtls"] = "DTLS";
 	capitalize_string_remaps["eol"] = "EOL";
 	capitalize_string_remaps["erp"] = "ERP";

--- a/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
@@ -550,7 +550,8 @@ namespace GodotTools.Export
         /// alongside would route the exported game straight back to the .NET host.
         /// </remarks>
         public string BuildDropIn(string publishOutputDir, string assemblyName, string buildConfig,
-            string runtimeIdentifier, string arch, string? macOSDeploymentTarget, bool keepWebSymbols)
+            string runtimeIdentifier, string arch, string? macOSDeploymentTarget, bool keepWebSymbols,
+            bool incrementalGcDefault)
         {
             // Create refuses any target set the backend cannot build, but it sees
             // one publish config and the caller loops over every architecture of
@@ -676,6 +677,7 @@ namespace GodotTools.Export
                 // entry lands as UNINITIALIZED where cmake's own is a FILEPATH.
                 $"-DCMAKE_MAKE_PROGRAM:FILEPATH={CMakePath(_ninjaExe)}",
                 "-DDN2CPP_DOTNET_MODULE=ON",
+                $"-DDN2CPP_GC_INCREMENTAL_DEFAULT={(incrementalGcDefault ? "ON" : "OFF")}",
                 $"-DDN2CPP_APP_DIR={CMakePath(genDir)}",
                 $"-DDN2CPP_APP_NAME={targetName}",
             };

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -81,24 +81,6 @@ namespace GodotTools.Export
                 );
             }
 
-            if (platform.GetOsName().Equals(OS.Platforms.Web, StringComparison.OrdinalIgnoreCase))
-            {
-                exportOptionList.Add
-                (
-                    new Godot.Collections.Dictionary()
-                    {
-                        {
-                            "option", new Godot.Collections.Dictionary()
-                            {
-                                { "name", "dotnet/dn2cpp/keep_symbols" },
-                                { "type", (int)Variant.Type.Bool }
-                            }
-                        },
-                        { "default_value", false }
-                    }
-                );
-            }
-
             exportOptionList.Add
             (
                 new Godot.Collections.Dictionary()
@@ -157,6 +139,41 @@ namespace GodotTools.Export
                     { "default_value", (int)ExportBackend.HostRuntime }
                 }
             );
+
+            if (platform.GetOsName().Equals(OS.Platforms.Web, StringComparison.OrdinalIgnoreCase))
+            {
+                exportOptionList.Add
+                (
+                    new Godot.Collections.Dictionary()
+                    {
+                        {
+                            "option", new Godot.Collections.Dictionary()
+                            {
+                                { "name", "dotnet/dn2cpp/keep_symbols" },
+                                { "type", (int)Variant.Type.Bool }
+                            }
+                        },
+                        { "default_value", false }
+                    }
+                );
+            }
+            else
+            {
+                exportOptionList.Add
+                (
+                    new Godot.Collections.Dictionary()
+                    {
+                        {
+                            "option", new Godot.Collections.Dictionary()
+                            {
+                                { "name", "dotnet/dn2cpp/incremental_gc" },
+                                { "type", (int)Variant.Type.Bool }
+                            }
+                        },
+                        { "default_value", true }
+                    }
+                );
+            }
             return exportOptionList;
         }
 
@@ -253,6 +270,8 @@ namespace GodotTools.Export
             var exportBackend = (ExportBackend)(int)GetOption("dotnet/export_backend");
             bool keepWebSymbols = platform == OS.Platforms.Web
                 && (bool)GetOption("dotnet/dn2cpp/keep_symbols");
+            bool incrementalGcDefault = platform != OS.Platforms.Web
+                && (bool)GetOption("dotnet/dn2cpp/incremental_gc");
 
             // Read before anything is published: every way the Web can fail is a
             // preset checkbox, and finding that out after a transpile and a native
@@ -482,7 +501,7 @@ namespace GodotTools.Export
                         : null;
                     string? dn2CppContentsDir = dn2CppExporter?.BuildDropIn(publishOutputDir,
                         GodotSharpDirs.ProjectAssemblyName, buildConfig, runtimeIdentifier, arch,
-                        macOSDeploymentTarget, keepWebSymbols);
+                        macOSDeploymentTarget, keepWebSymbols, incrementalGcDefault);
 
                     // Where THIS slot's library landed, for the iOS tail below: it
                     // reads one {Assembly}.dylib per entry, so an entry has to be a


### PR DESCRIPTION
## Summary

- Add `dotnet/dn2cpp/incremental_gc` for the dn2cpp backend
- Enable it by default on supported platforms
- Preserve the `dn2cpp` branding and place backend-specific options immediately after Export Backend
- Hide Incremental GC on Web while continuing to show Keep Symbols
- Explicitly pass ON/OFF to the persistent CMake build slot on every build to prevent stale values from carrying over

Corresponding dn2cpp change: https://github.com/takuma-komatsu/dn2cpp/pull/96

## Verification

- Incremental build of the macOS Mono editor
- `build_assemblies.py --godot-output-dir ./bin`
- Opened the export dialog for `EditorExportSample` in the patched editor
- `./gates/setup-godot-fork.sh`
- `./gates/build-and-run-godot-editor-export.sh`
- `./gates/build-and-run-godot-editor-export-web.sh`
- `git diff --check`
