### PR TITLE
CI: Avoid godot-cpp archive argument limit

### DIFF
--- a/.github/actions/godot-cpp-build/action.yml
+++ b/.github/actions/godot-cpp-build/action.yml
@@ -33,6 +33,11 @@ runs:
       shell: sh
       run: ${{ inputs.bin }} --headless --dump-gdextension-interface --dump-extension-api
 
+    - name: Enable archive response files
+      if: runner.os == 'Linux'
+      shell: sh
+      run: git -C ./godot-cpp apply "${GITHUB_ACTION_PATH}/use-archive-response-file.patch"
+
     - name: SCons Build
       shell: sh
       env:

--- a/.github/actions/godot-cpp-build/use-archive-response-file.patch
+++ b/.github/actions/godot-cpp-build/use-archive-response-file.patch
@@ -1,0 +1,14 @@
+diff --git a/SConstruct b/SConstruct
+index 419264d..9784b8c 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -44,6 +44,9 @@ if scons_cache_path is not None:
+     Decider("MD5")
+ 
+ cpp_tool.generate(env)
++# Custom APIs can generate enough wrappers to exceed the process argument limit.
++env["ARCOM"] = '${TEMPFILE("$AR $ARFLAGS $TARGET $SOURCES", "$ARCOMSTR")}'
++
+ library = env.GodotCPP()
+ 
+ Return("env")


### PR DESCRIPTION
## What problem(s) does this PR solve?

The Linux Editor with Mono job fails while archiving the generated godot-cpp wrappers because the `ar` command exceeds the Linux per-argument limit:

- [Failing Linux job](https://github.com/takuma-komatsu/godot-dn2cpp/actions/runs/33475574709/job/99754224061)
- [godot-cpp upstream bug #1729](https://github.com/godotengine/godot-cpp/issues/1729)
- [godot-cpp upstream fix PR #1731](https://github.com/godotengine/godot-cpp/pull/1731)

## Additional information

This is a temporary, Linux-only workaround based on the response-file approach proposed upstream. After checking out godot-cpp, the composite action patches its SCons `ARCOM` to use SCons standard `TEMPFILE` wrapper. Large archives are then created through `ar @response-file` instead of placing every object path in one shell argument.

The upstream PR is not copied verbatim. Its current custom builder also targets MinGW, whose upstream CI job is failing. Keeping the standard SCons static-library builder preserves its dependency handling and propagates the archiver exit status, while limiting the workaround to the Linux job that currently reproduces the problem.

The patch should be removed after an upstream fix is merged and available on the godot-cpp branch used by this workflow.

Validation performed:

- Applied the patch cleanly to the official godot-cpp 4.5 branch.
- Built all wrappers generated from this fork extension API.
- Built the godot-cpp static library and final test GDExtension successfully.
- Forced the response-file threshold during verification and confirmed an `ar @/tmp/...` invocation.
- Parsed the composite action as YAML and ran `git diff --check`.

AI disclosure: Codex was used to inspect the failing CI log, review the upstream issue and proposed fix, implement the narrower workaround, and run the validation described above.