### PR TITLE
Export Windows DLLs beside executable

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/Dn2CppExporter.cs
@@ -88,10 +88,10 @@ namespace GodotTools.Export
 
         /// <summary>
         /// Project setting (PackedStringArray) of native library paths staged
-        /// beside the drop-in, so the platform exporter packages them the same
-        /// way — into the APK's lib/&lt;abi&gt;/ on Android, next to the data
-        /// directory elsewhere — e.g. a binding SDK's shared objects the
-        /// drop-in links against or dlopens.
+        /// with the drop-in for the platform exporter to package — into the
+        /// APK's lib/&lt;abi&gt;/ on Android and beside the executable on Windows,
+        /// for example. These are shared objects the drop-in links against or
+        /// opens dynamically.
         /// </summary>
         private const string ExtraSharedObjectsSetting = "dotnet/dn2cpp/extra_shared_objects";
 
@@ -963,11 +963,11 @@ namespace GodotTools.Export
             LogLine($"staged {stagedLibrary}");
             GD.Print($"dn2cpp: staged {stagedLibrary}");
 
-            // Project-declared extra native libraries, staged beside the drop-in
-            // so the platform exporter packages them by the same rules it
-            // packages the drop-in itself (Android tags shared objects into the
-            // APK's lib/<abi>/; the Web copies them next to index.html and
-            // preloads them). A missing path is an error, not a skip: a typo
+            // Project-declared extra native libraries are collected in the same
+            // staging tree as the drop-in; ExportPlugin chooses their final
+            // platform location (Android's lib/<abi>/, the Windows executable
+            // directory, or the Web page directory and preload list). A missing
+            // path is an error, not a skip: a typo
             // silently shipping a game without its native library would surface
             // as a dlopen failure on a player's machine, the one place this
             // diagnostic cannot reach anybody.

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -617,10 +617,19 @@ namespace GodotTools.Export
                                     }
                                     else
                                     {
+                                        // The stock Windows template opens the NativeAOT drop-in from its data
+                                        // directory without adding that directory to the PE dependency search.
+                                        // Keep the drop-in in its engine-defined location, but put project-declared
+                                        // sibling DLLs beside the executable where the OS loader finds them.
+                                        bool isDn2CppWindowsDependency = dn2CppContentsDir is not null
+                                            && platform == OS.Platforms.Windows
+                                            && Path.GetFileName(path) != $"{GodotSharpDirs.ProjectAssemblyName}.dll";
                                         AddSharedObject(path, tags: null,
-                                            Path.Join(projectDataDirName,
-                                                Path.GetRelativePath(exportContentsDir,
-                                                    Path.GetDirectoryName(path)!)));
+                                            isDn2CppWindowsDependency
+                                                ? string.Empty
+                                                : Path.Join(projectDataDirName,
+                                                    Path.GetRelativePath(exportContentsDir,
+                                                        Path.GetDirectoryName(path)!)));
                                     }
                                 }
                             }

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -504,13 +504,7 @@ godot_plugins_initialize_fn try_load_native_aot_library(void *&r_aot_dll_handle)
 #error "Platform not supported (yet?)"
 #endif
 
-#if defined(WINDOWS_ENABLED)
-	OS::GDExtensionData library_data;
-	library_data.also_set_library_path = true;
-	Error err = OS::get_singleton()->open_dynamic_library(native_aot_so_path, r_aot_dll_handle, &library_data);
-#else
 	Error err = OS::get_singleton()->open_dynamic_library(native_aot_so_path, r_aot_dll_handle);
-#endif
 
 	if (err != OK) {
 		return nullptr;


### PR DESCRIPTION
The official Windows export templates use the upstream NativeAOT loader path. Keep the dn2cpp drop-in in data_<project>_windows_<arch>, package project-declared dependency DLLs beside the executable where the standard Windows loader resolves them, and remove the fork-only loader-path override. Verified through dn2cpp's Windows desktop editor-export gate with both official Release and Debug templates, including the dependency P/Invoke marker.